### PR TITLE
Add a link to the Treeherder resultset in the console log.

### DIFF
--- a/vars/submitToTreeherder.groovy
+++ b/vars/submitToTreeherder.groovy
@@ -44,6 +44,8 @@ def call(String project,
   routingKey = "${PULSE_USR}.${payload.productName}"
   schema = libraryResource 'org/mozilla/fxtest/pulse/schemas/treeherder.json'
   publishToPulse(exchange, routingKey, JsonOutput.toJson(payload), schema)
+  treeherderURL = "https://treeherder.mozilla.org/#/jobs?repo=${payload.productName}&revision=${payload.origin.revision}"
+  echo "Results will be available to view at $treeherderURL"
 }
 
 def getMachine() {


### PR DESCRIPTION
Fixes #11 

Tested [here](https://fx-test-jenkins-dev.stage.mozaws.net:8443/job/fxapom.adhoc/49/console), though because there hasn't been a recent push to FxAPOM there are no resultsets on Treeherder production. The link works if you replace mozilla.org with allizom.org.