### PR TITLE
Change name of TBPL log file to buildbot_text.

### DIFF
--- a/tests/submitToTreeherderTests.groovy
+++ b/tests/submitToTreeherderTests.groovy
@@ -38,4 +38,26 @@ class SubmitToTreeherderTests extends BasePipelineTest {
         assert !display.containsKey('groupName')
     }
 
+    @Test
+    void getLogsReturnsListOfLinkMaps() {
+        helper.registerAllowedMethod('publishToS3', [String.class, String.class], {path, bucket ->
+            [[url:'linkURL', name:'linkName']]})
+        def script = loadScript('vars/submitToTreeherder.groovy')
+        def links = script.getLogs('foo')
+        assert links.size() == 1
+        assert links[0].url == 'linkURL'
+        assert links[0].name == 'linkName'
+    }
+
+    @Test
+    void tbplLogNameIsModified() {
+        helper.registerAllowedMethod('publishToS3', [String.class, String.class], {path, bucket ->
+            [[url:'linkURL', name:'my-tbpl-log']]})
+        def script = loadScript('vars/submitToTreeherder.groovy')
+        def links = script.getLogs('foo')
+        assert links.size() == 1
+        assert links[0].url == 'linkURL'
+        assert links[0].name == 'buildbot_text'
+    }
+
 }

--- a/vars/submitToTreeherder.groovy
+++ b/vars/submitToTreeherder.groovy
@@ -112,7 +112,8 @@ def getLogs(logPath) {
   if ( logPath != null ) {
     logLinks = publishToS3(logPath, 'net-mozaws-stage-fx-test-treeherder')
     for (link in logLinks) {
-      links.add([url: link.url, name: link.name])
+      name = link.name =~ 'tbpl' ? 'buildbot_text' : link.name
+      links.add([url: link.url, name: name])
     }
   }
   return links


### PR DESCRIPTION
Fixes #12 

I've included a test for this change, but also ran an adhoc [here](https://fx-test-jenkins-dev.stage.mozaws.net:8443/job/fxapom.adhoc/50/console). Search in the console log for "buildbot_text". As a result, log parsing is now attempted, but [apparently fails](https://treeherder.allizom.org/#/jobs?repo=fxapom&revision=cd87f7f8bb06ff035ac716081e01a6f55046911d&selectedJob=84928378). We can take care of this independently.