### PR TITLE
Execute run script inside custom Docker image

### DIFF
--- a/src/org/mozilla/fxtest/ServiceBook.groovy
+++ b/src/org/mozilla/fxtest/ServiceBook.groovy
@@ -48,11 +48,11 @@ def runStage(test) {
             node {
                 checkout([
                     $class: 'GitSCM',
-                    branches: [[name: '*/master']],
+                    branches: [[name: 'run-in-docker']],
                     doGenerateSubmoduleConfigurations: false,
                     extensions: [[$class: 'CleanCheckout']],
                     submoduleCfg: [],
-                    userRemoteConfigs: [[url: test.url + '.git']]])
+                    userRemoteConfigs: [[url: 'https://github.com/davehunt/kinto-integration-tests.git']]])
                 def customImage = docker.build("${test.name}:${env.BUILD_ID}")
                 customImage.inside {
                   sh 'chmod +x run'


### PR DESCRIPTION
**DO NOT MERGE - This pull request is for demonstration and not intended for review/merge.**

In this patch I have modified the ServiceBook function to build a custom Docker image based on an expected Dockerfile. This image is then used for the run script, which no longer needs to pull/run a Docker image from Docker Hub or similar. I also fixed an issue that caused a superfluous stage to be created in the Jenkins build. Note that in order for projects to use this changes, they would need to modify their `run` scripts appropriately.